### PR TITLE
Implement basic support for inline message handling (ping) and connection closing (quit).

### DIFF
--- a/src/backend/redis.rs
+++ b/src/backend/redis.rs
@@ -70,9 +70,9 @@ impl RequestProcessor for RedisRequestProcessor {
 
     fn process(&self, req: OrderedMessages<Self::Message>, stream: TcpStreamFuture) -> Self::Future {
         let inner = stream
-            .and_then(move |server| redis::write_ordered_messages(server, req))
-            .and_then(move |(server, msgs, _n)| redis::read_messages(server, msgs))
-            .and_then(move |(server, _n, resps)| ok((server, resps)));
+            .and_then(move |server| redis::write_server_ordered_messages(server, req))
+            .and_then(move |(server, msgs, _nw)| redis::read_messages(server, msgs))
+            .and_then(move |(server, resps)| ok((server, resps)));
         Box::new(inner)
     }
 }

--- a/src/routing/fixed.rs
+++ b/src/routing/fixed.rs
@@ -155,6 +155,7 @@ where
     type Future = Box<Future<Item = OrderedMessages<T::Message>, Error = RouterError> + Send + 'static>;
 
     fn route(&self, req: OrderedMessages<T::Message>) -> Result<Self::Future, RouterError> {
+        debug!("[fixed] running batch of {} messages", req.len());
         let f = self.run_batch(req)?;
         Ok(Box::new(f))
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -46,16 +46,3 @@ pub trait StreamExt: Stream {
         batch::new(self, capacity)
     }
 }
-
-/// Calculates the size of bytes for all items in a batch.
-pub fn get_ordered_batch_size<T>(batch: &Vec<(u64, i64, T)>) -> usize
-where
-    T: Sizable,
-{
-    batch.into_iter().fold(0, |acc, (_, _, x)| acc + x.size())
-}
-
-/// A type that can report back its own size in bytes.
-pub trait Sizable {
-    fn size(&self) -> usize;
-}

--- a/synchrotron-test/src/main.rs
+++ b/synchrotron-test/src/main.rs
@@ -262,7 +262,13 @@ mod redis_tests {
         let value: isize = conn.get("").unwrap();
         assert_eq!(value, 19);
 
-        let _ = conn.send_packed_command(b"quit").unwrap();
+        // Now end the connection with QUIT.
+        let _ = conn.send_packed_command(b"quit\r\n").unwrap();
+        let _ = conn.recv_response().unwrap();
+
+        // We still have our sending side open, so we can send the PING command, but trying to
+        // receive the command should fail.
+        let _ = conn.send_packed_command(b"ping\r\n").unwrap();
         let _ = conn.recv_response().unwrap();
 
         drop(_daemons);

--- a/synchrotron-test/src/main.rs
+++ b/synchrotron-test/src/main.rs
@@ -232,7 +232,6 @@ mod redis_tests {
     fn test_null_key() {
         let (_daemons, redis_url) = start_daemons(2);
 
-        // A simple set and then get.
         let client = redis::Client::open(redis_url.as_str()).unwrap();
         let conn = client.get_connection().unwrap();
 
@@ -250,4 +249,23 @@ mod redis_tests {
 
         drop(_daemons);
     }
+
+    #[test]
+    #[should_panic]
+    fn test_quit_drops_conn() {
+        let (_daemons, redis_url) = start_daemons(3);
+
+        let client = redis::Client::open(redis_url.as_str()).unwrap();
+        let conn = client.get_connection().unwrap();
+
+        let _: () = conn.set("", 19).unwrap();
+        let value: isize = conn.get("").unwrap();
+        assert_eq!(value, 19);
+
+        let _ = conn.send_packed_command(b"quit").unwrap();
+        let _ = conn.recv_response().unwrap();
+
+        drop(_daemons);
+    }
+
 }


### PR DESCRIPTION
This adds basic support for two features: handling messages inline (without talking to a backend) and closing connections intentionally.

Handling messages inline isn't super important but does allow us to do things like avoid sending PINGs to an actual backend server when responding ourselves is good enough.  Similarly, _we_ can gracefully handle a client closing a connection on us abruptly, but we would also like to handle a client trying to gracefully close a connection.

The support for this stuff is predicated on being able to hand the internal machinery both requests to process and pre-baked response (since we reuse buffers between reads and writes) and have things flow through without being touched if they're pre-baked responses.  This is implementation-specific and not necessarily given for free through any API surface, but it serves as a model going forward.

The "basic"ness of this support lies in the fact that we actually still going through the routing phase for these messages.  While we can pre-bake responses to send to the client, we still get to the point where we're hashing the "key" of these messages, and attempting a 0-byte write (because we _don't_ want to actually send anything) to the backend.  This is less than ideal, but I plan on at least exploring a more complete solution in the future.