### PR TITLE
Add support for backend timeouts.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@
 #![feature(nll)]
 #![feature(associated_type_defaults)]
 #![feature(duration_as_u128)]
-#![feature(extern_prelude)]
 #![feature(option_replace)]
 #![recursion_limit = "1024"]
 

--- a/synchrotron-test/src/daemons.rs
+++ b/synchrotron-test/src/daemons.rs
@@ -22,7 +22,8 @@ macro_rules! get_redis_config {
                         "default": {{
                             "addresses": ["127.0.0.1:{}", "127.0.0.1:{}"],
                             "options": {{
-                                "cooloff_timeout_ms": "2000"
+                                "cooloff_timeout_ms": "2000",
+                                "timeout_ms": "100"
                             }}
                         }}
                     }},


### PR DESCRIPTION
Add the ability to define a timeout on operations to backends.

This does not affect the "frontend" of Synchrotron at all: a client could connect and Slowloris us and this wouldn't do anything for that.  By virtue of batching requests to backends, this means that the timeout itself could technically be a result of batch sizing.

Right now, we batch requests from the client and then enqueue them, which splits them per-backend.  If you had a batch of items, more than one, at least, for a given backend, the backend will run that batch exclusively when it can acquire the connection.  The timeout starts when the batch is received and stored in the connection worker, thus "scheduling" it.

That means that, theoretically, as your batch is being actively worked out, we might timeout the overall chunk of work which leaves some messages unresponded to: we could be in the "read" step of getting the responses back from the backend, literally reading the messages from the stream, sending the responses to the message queues of clients, and poof, be essentially pre-empted by the timeout.

Obviously, we still send an error response for each of those unfulfilled messages so that our client doesn't hang... but it means that we're not timing out purely on seeing the first byte, etc, so everything has to be written to the backend, come back with responses, and be sent back to the client's message queue all within the timeout.

We might end up revisiting this in the future, who knows.  I think this is a reasonably-performant approach for right now, and there's not much to be gained from applying timeouts at an individual level or anything.

By default, we've set the timeout at 1000ms.