### PR TITLE
Capture the test result exit code and regurgitate it at the end.

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -5,4 +5,6 @@ cargo build
 
 pushd synchrotron-test
 cargo test
+RESULT=$?
 popd
+exit $RESULT


### PR DESCRIPTION
Integration test failures don't actually tank the CI run, and they are stable enough now that we should care about them failing.

Fixes #24.