### PR TITLE
Add support for named backends.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,8 @@ env:
 
 matrix:
   include:
-    # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
-    - env: TARGET=arm-unknown-linux-gnueabi
-    - env: TARGET=armv7-unknown-linux-gnueabihf
-    # This breaks when it goes to compile rust-crypto. *shrug*
-    #- env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu
-
-    # OSX
-    - env:
-        - TARGET=i686-apple-darwin
-        - REDIS_BIN=/usr/local/bin/redis-server
-      os: osx
     - env:
         - TARGET=x86_64-apple-darwin
         - REDIS_BIN=/usr/local/bin/redis-server

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -225,12 +225,9 @@ where
         // Build all of our backends for this pool.
         let mut backends = Vec::new();
         for address in &self.config.addresses {
-            // TODO: generate a ketama suitable/possibly-stable string identifier by parsing the
-            // address
-            let identifier = format!("{}", address);
             let backend = Backend::new(
-                *address,
-                identifier,
+                address.address,
+                address.identifier.clone(),
                 self.processor.clone(),
                 options.clone(),
                 self.noreply,

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -17,8 +17,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+use super::BackendAddress;
 use config::{Config, ConfigError, File};
-use std::{collections::HashMap, env, net::SocketAddr};
+use std::{collections::HashMap, env};
 
 #[derive(Deserialize, Default, Clone, Debug)]
 pub struct Configuration {
@@ -43,7 +44,7 @@ pub struct ListenerConfiguration {
 
 #[derive(Deserialize, Default, Clone, Debug)]
 pub struct PoolConfiguration {
-    pub addresses: Vec<SocketAddr>,
+    pub addresses: Vec<BackendAddress>,
     pub options: Option<HashMap<String, String>>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ extern crate warp;
 extern crate config;
 extern crate crypto;
 extern crate pruefung;
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate slab;


### PR DESCRIPTION
This adds the ability to define identifiers for individual backend addresses, such that you can either specify addresses in their normal form of "x.x.x.x:xxxx" or with an identifier: "x.x.x.x:xxxx foobar".

This is required to allow specific distribution algorithms, like libketama, to be able to generate a stable ring even if one node is intentionally replaced with another.  Actual IP/port values alone may not be enough, even when sorted.